### PR TITLE
Add controller unit tests

### DIFF
--- a/SWP_abschluss_projekt/SWP_abschluss_projekt.csproj
+++ b/SWP_abschluss_projekt/SWP_abschluss_projekt.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,13 +14,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/SWP_abschluss_projekt/SWP_abschluss_projekt.sln
+++ b/SWP_abschluss_projekt/SWP_abschluss_projekt.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.14.36121.58 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SWP_abschluss_projekt", "SWP_abschluss_projekt.csproj", "{88D2F6A3-D9BB-443B-A5C5-031FC6D227EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SWP_abschluss_projekt.Tests", "Tests/SWP_abschluss_projekt.Tests.csproj", "{38A8E532-F8F0-44AA-9082-F1CDE0FF7449}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{88D2F6A3-D9BB-443B-A5C5-031FC6D227EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{88D2F6A3-D9BB-443B-A5C5-031FC6D227EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{88D2F6A3-D9BB-443B-A5C5-031FC6D227EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{88D2F6A3-D9BB-443B-A5C5-031FC6D227EE}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {88D2F6A3-D9BB-443B-A5C5-031FC6D227EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {88D2F6A3-D9BB-443B-A5C5-031FC6D227EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {88D2F6A3-D9BB-443B-A5C5-031FC6D227EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {88D2F6A3-D9BB-443B-A5C5-031FC6D227EE}.Release|Any CPU.Build.0 = Release|Any CPU
+                {38A8E532-F8F0-44AA-9082-F1CDE0FF7449}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {38A8E532-F8F0-44AA-9082-F1CDE0FF7449}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {38A8E532-F8F0-44AA-9082-F1CDE0FF7449}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {38A8E532-F8F0-44AA-9082-F1CDE0FF7449}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/SWP_abschluss_projekt/Tests/SWP_abschluss_projekt.Tests.csproj
+++ b/SWP_abschluss_projekt/Tests/SWP_abschluss_projekt.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SWP_abschluss_projekt.csproj" />
+  </ItemGroup>
+</Project>

--- a/SWP_abschluss_projekt/Tests/Unit/FachControllerTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/FachControllerTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SWP_abschluss_projekt.Controllers;
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class FachControllerTests
+{
+    private SchulDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<SchulDbContext>()
+            .UseInMemoryDatabase(databaseName: "FachControllerTests")
+            .Options;
+        return new SchulDbContext(options);
+    }
+
+    [Test]
+    public async Task GetAll_Returns_All_Faecher()
+    {
+        using var context = CreateContext();
+        context.Faecher.Add(new Fach("M", new Lehrer("a","b")));
+        context.Faecher.Add(new Fach("E", new Lehrer("c","d")));
+        context.SaveChanges();
+        var controller = new FachController(context);
+
+        var result = await controller.GetAll();
+
+        Assert.AreEqual(2, result.Value?.Count());
+    }
+
+    [Test]
+    public async Task Create_Adds_Fach()
+    {
+        using var context = CreateContext();
+        var controller = new FachController(context);
+        var fach = new Fach("D", new Lehrer("e","f"));
+
+        var result = await controller.Create(fach);
+
+        Assert.AreEqual(1, context.Faecher.Count());
+        Assert.AreEqual(201, (result.Result as CreatedAtActionResult)?.StatusCode);
+    }
+}
+

--- a/SWP_abschluss_projekt/Tests/Unit/FachTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/FachTests.cs
@@ -1,0 +1,18 @@
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class FachTests
+{
+    [Test]
+    public void Constructor_Sets_Properties()
+    {
+        var lehrer = new Lehrer("Anna", "Bauer");
+        var fach = new Fach("Math", lehrer);
+
+        Assert.AreEqual("Math", fach.Bezeichnung);
+        Assert.AreSame(lehrer, fach.Lehrer);
+        Assert.IsEmpty(fach.Noten);
+    }
+}

--- a/SWP_abschluss_projekt/Tests/Unit/KlasseControllerTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/KlasseControllerTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SWP_abschluss_projekt.Controllers;
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class KlasseControllerTests
+{
+    private SchulDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<SchulDbContext>()
+            .UseInMemoryDatabase(databaseName: "KlasseControllerTests")
+            .Options;
+        return new SchulDbContext(options);
+    }
+
+    [Test]
+    public async Task GetAll_Returns_All_Klassen()
+    {
+        using var context = CreateContext();
+        context.Klassen.Add(new Klasse("1A", new Lehrer("a","b")));
+        context.Klassen.Add(new Klasse("2B", new Lehrer("c","d")));
+        context.SaveChanges();
+        var controller = new KlasseController(context);
+
+        var result = await controller.GetAll();
+
+        Assert.AreEqual(2, result.Value?.Count());
+    }
+
+    [Test]
+    public async Task Create_Adds_Klasse()
+    {
+        using var context = CreateContext();
+        var controller = new KlasseController(context);
+        var klasse = new Klasse("3C", new Lehrer("e","f"));
+
+        var result = await controller.Create(klasse);
+
+        Assert.AreEqual(1, context.Klassen.Count());
+        Assert.AreEqual(201, (result.Result as CreatedAtActionResult)?.StatusCode);
+    }
+}
+

--- a/SWP_abschluss_projekt/Tests/Unit/KlasseTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/KlasseTests.cs
@@ -1,0 +1,18 @@
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class KlasseTests
+{
+    [Test]
+    public void Constructor_Sets_Properties()
+    {
+        var lehrer = new Lehrer("Eva", "Schmidt");
+        var klasse = new Klasse("3A", lehrer);
+
+        Assert.AreEqual("3A", klasse.Name);
+        Assert.AreSame(lehrer, klasse.Klassenvorstand);
+        Assert.IsEmpty(klasse.Schueler);
+    }
+}

--- a/SWP_abschluss_projekt/Tests/Unit/LehrerControllerTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/LehrerControllerTests.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SWP_abschluss_projekt.Controllers;
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class LehrerControllerTests
+{
+    private SchulDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<SchulDbContext>()
+            .UseInMemoryDatabase(databaseName: "LehrerControllerTests")
+            .Options;
+        return new SchulDbContext(options);
+    }
+
+    [Test]
+    public async Task GetAll_Returns_All_Lehrer()
+    {
+        using var context = CreateContext();
+        context.Lehrer.AddRange(new Lehrer("A","B"), new Lehrer("C","D"));
+        context.SaveChanges();
+        var controller = new LehrerController(context);
+
+        var result = await controller.GetAll();
+
+        Assert.AreEqual(2, result.Value?.Count());
+    }
+
+    [Test]
+    public async Task GetById_NotFound_When_Missing()
+    {
+        using var context = CreateContext();
+        var controller = new LehrerController(context);
+
+        var result = await controller.GetById(1);
+
+        Assert.IsInstanceOf<NotFoundResult>(result.Result);
+    }
+
+    [Test]
+    public async Task Create_Adds_Lehrer()
+    {
+        using var context = CreateContext();
+        var controller = new LehrerController(context);
+        var neu = new Lehrer("E","F");
+
+        var result = await controller.Create(neu);
+
+        Assert.AreEqual(1, context.Lehrer.Count());
+        Assert.AreEqual(201, (result.Result as CreatedAtActionResult)?.StatusCode);
+    }
+}
+

--- a/SWP_abschluss_projekt/Tests/Unit/LehrerTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/LehrerTests.cs
@@ -1,0 +1,18 @@
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class LehrerTests
+{
+    [Test]
+    public void Constructor_Sets_Base_Properties()
+    {
+        var lehrer = new Lehrer("Tom", "Trauner");
+
+        Assert.AreEqual("Tom", lehrer.Vorname);
+        Assert.AreEqual("Trauner", lehrer.Nachname);
+        Assert.IsEmpty(lehrer.Faecher);
+        Assert.IsEmpty(lehrer.KlassenAlsKV);
+    }
+}

--- a/SWP_abschluss_projekt/Tests/Unit/NoteTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/NoteTests.cs
@@ -1,0 +1,19 @@
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class NoteTests
+{
+    [Test]
+    public void Constructor_Sets_Properties()
+    {
+        var schueler = new Schueler("Max", "Muster", new Klasse("1A", new Lehrer("L","B")));
+        var fach = new Fach("Deutsch", new Lehrer("T","S"));
+        var note = new Note(schueler, fach, 1);
+
+        Assert.AreSame(schueler, note.Schueler);
+        Assert.AreSame(fach, note.Fach);
+        Assert.AreEqual(1, note.Wert);
+    }
+}

--- a/SWP_abschluss_projekt/Tests/Unit/PersonTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/PersonTests.cs
@@ -1,0 +1,15 @@
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class PersonTests
+{
+    [Test]
+    public void Constructor_Sets_Names()
+    {
+        var person = new Person("Max", "Mustermann");
+        Assert.AreEqual("Max", person.Vorname);
+        Assert.AreEqual("Mustermann", person.Nachname);
+    }
+}

--- a/SWP_abschluss_projekt/Tests/Unit/RaumControllerTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/RaumControllerTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SWP_abschluss_projekt.Controllers;
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class RaumControllerTests
+{
+    private SchulDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<SchulDbContext>()
+            .UseInMemoryDatabase(databaseName: "RaumControllerTests")
+            .Options;
+        return new SchulDbContext(options);
+    }
+
+    [Test]
+    public async Task GetAll_Returns_All_Raeume()
+    {
+        using var context = CreateContext();
+        context.Raeume.AddRange(new Raum("R1"), new Raum("R2"));
+        context.SaveChanges();
+        var controller = new RaumController(context);
+
+        var result = await controller.GetAll();
+
+        Assert.AreEqual(2, result.Value?.Count());
+    }
+
+    [Test]
+    public async Task Create_Adds_Raum()
+    {
+        using var context = CreateContext();
+        var controller = new RaumController(context);
+        var raum = new Raum("R3");
+
+        var result = await controller.Create(raum);
+
+        Assert.AreEqual(1, context.Raeume.Count());
+        Assert.AreEqual(201, (result.Result as CreatedAtActionResult)?.StatusCode);
+    }
+}
+

--- a/SWP_abschluss_projekt/Tests/Unit/RaumTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/RaumTests.cs
@@ -1,0 +1,15 @@
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class RaumTests
+{
+    [Test]
+    public void Constructor_Sets_Bezeichnung()
+    {
+        var raum = new Raum("R101");
+
+        Assert.AreEqual("R101", raum.Bezeichnung);
+    }
+}

--- a/SWP_abschluss_projekt/Tests/Unit/SchuelerControllerTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/SchuelerControllerTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SWP_abschluss_projekt.Controllers;
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class SchuelerControllerTests
+{
+    private SchulDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<SchulDbContext>()
+            .UseInMemoryDatabase(databaseName: "SchuelerControllerTests")
+            .Options;
+        return new SchulDbContext(options);
+    }
+
+    [Test]
+    public async Task GetById_Returns_Schueler_When_Found()
+    {
+        using var context = CreateContext();
+        var klasse = new Klasse("1A", new Lehrer("k","v"));
+        var schueler = new Schueler("Max","Muster", klasse);
+        context.Klassen.Add(klasse);
+        context.Schueler.Add(schueler);
+        context.SaveChanges();
+        var controller = new SchuelerController(context);
+
+        var result = await controller.GetById(schueler.Id);
+
+        Assert.AreEqual(schueler.Id, result.Value?.Id);
+    }
+
+    [Test]
+    public async Task Delete_Removes_Schueler()
+    {
+        using var context = CreateContext();
+        var klasse = new Klasse("1A", new Lehrer("k","v"));
+        var schueler = new Schueler("Tim","Test", klasse);
+        context.Klassen.Add(klasse);
+        context.Schueler.Add(schueler);
+        context.SaveChanges();
+        var controller = new SchuelerController(context);
+
+        var response = await controller.Delete(schueler.Id);
+
+        Assert.IsInstanceOf<NoContentResult>(response);
+        Assert.AreEqual(0, context.Schueler.Count());
+    }
+}
+

--- a/SWP_abschluss_projekt/Tests/Unit/SchuelerTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/SchuelerTests.cs
@@ -1,0 +1,19 @@
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class SchuelerTests
+{
+    [Test]
+    public void Constructor_Sets_Properties()
+    {
+        var klasse = new Klasse("1B", new Lehrer("L","B"));
+        var schueler = new Schueler("Tim", "Test", klasse);
+
+        Assert.AreEqual("Tim", schueler.Vorname);
+        Assert.AreEqual("Test", schueler.Nachname);
+        Assert.AreSame(klasse, schueler.Klasse);
+        Assert.IsEmpty(schueler.Noten);
+    }
+}

--- a/SWP_abschluss_projekt/Tests/Unit/StundenplanEintragTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/StundenplanEintragTests.cs
@@ -1,0 +1,26 @@
+using System;
+using SWP_abschluss_projekt.Models;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class StundenplanEintragTests
+{
+    [Test]
+    public void Constructor_Sets_Properties()
+    {
+        var klasse = new Klasse("1A", new Lehrer("A","B"));
+        var fach = new Fach("Mathe", new Lehrer("C","D"));
+        var raum = new Raum("R1");
+        var start = new DateTime(2024,1,1,8,0,0);
+        var end = new DateTime(2024,1,1,9,0,0);
+
+        var eintrag = new StundenplanEintrag(klasse, fach, raum, start, end);
+
+        Assert.AreSame(klasse, eintrag.Klasse);
+        Assert.AreSame(fach, eintrag.Fach);
+        Assert.AreSame(raum, eintrag.Raum);
+        Assert.AreEqual(start, eintrag.Start);
+        Assert.AreEqual(end, eintrag.End);
+    }
+}

--- a/SWP_abschluss_projekt/Tests/Unit/WeatherForecastTests.cs
+++ b/SWP_abschluss_projekt/Tests/Unit/WeatherForecastTests.cs
@@ -1,0 +1,17 @@
+using SWP_abschluss_projekt;
+using NUnit.Framework;
+
+namespace SWP_abschluss_projekt.Tests.Unit;
+
+public class WeatherForecastTests
+{
+    [Test]
+    public void TemperatureF_Computes_From_Celsius()
+    {
+        var forecast = new WeatherForecast { TemperatureC = 0 };
+        Assert.AreEqual(32, forecast.TemperatureF);
+
+        forecast.TemperatureC = 100;
+        Assert.AreEqual(212, forecast.TemperatureF);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for the API controllers
- keep assembly info generation disabled to avoid duplicate attributes
- switch test framework from xUnit to NUnit

## Testing
- `dotnet test SWP_abschluss_projekt/Tests/SWP_abschluss_projekt.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd79dee70832ca29ad4255356f586